### PR TITLE
Fixed copyright and SwiftFormat header text

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,6 +1,10 @@
-# Rules
+ # Rules
+# makes sure the self. prefix is added where appropriate
 --self insert
---stripunusedargs closure-only
+# only strips unused arguments (replacing with _) in closures, not methods
+--stripunusedargs closure-only 
+# sets the header block to supplied text
+--header "Copyright © {year} SpotHero, Inc. All rights reserved."
 
 # Disabled Rules
 --disable specifiers # because it isn't configurable

--- a/Sources/ZincFramework/Commands/HelpCommand.swift
+++ b/Sources/ZincFramework/Commands/HelpCommand.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero. All rights reserved.
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 class HelpCommand: Command {
     func run() throws {

--- a/Sources/ZincFramework/Commands/LintCommand.swift
+++ b/Sources/ZincFramework/Commands/LintCommand.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero. All rights reserved.
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 class LintCommand: Command {
     func run() throws {

--- a/Sources/ZincFramework/Commands/SyncCommand.swift
+++ b/Sources/ZincFramework/Commands/SyncCommand.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero. All rights reserved.
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 class SyncCommand: Command {
     func run() throws {

--- a/Sources/ZincFramework/Constants.swift
+++ b/Sources/ZincFramework/Constants.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero. All rights reserved.
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 class Constants {
     /// Denotes the default filenames to check if none are provided, in prioritized order.

--- a/Sources/ZincFramework/Enums/SourceType.swift
+++ b/Sources/ZincFramework/Enums/SourceType.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero. All rights reserved.
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 public enum SourceType {
     case `default`

--- a/Sources/ZincFramework/Errors/ZincError.swift
+++ b/Sources/ZincFramework/Errors/ZincError.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero. All rights reserved.
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 import Foundation
 

--- a/Sources/ZincFramework/Errors/ZincfileParsingError.swift
+++ b/Sources/ZincFramework/Errors/ZincfileParsingError.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero. All rights reserved.
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 import Foundation
 

--- a/Sources/ZincFramework/Extensions/String+Validation.swift
+++ b/Sources/ZincFramework/Extensions/String+Validation.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero. All rights reserved.
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 import Foundation
 

--- a/Sources/ZincFramework/Helpers/Commander.swift
+++ b/Sources/ZincFramework/Helpers/Commander.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero. All rights reserved.
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 import Foundation
 

--- a/Sources/ZincFramework/Helpers/Farmer.swift
+++ b/Sources/ZincFramework/Helpers/Farmer.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero. All rights reserved.
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 import Foundation
 import Yams

--- a/Sources/ZincFramework/Helpers/FileClerk.swift
+++ b/Sources/ZincFramework/Helpers/FileClerk.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero. All rights reserved.
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 import Foundation
 

--- a/Sources/ZincFramework/Helpers/Lumberjack.swift
+++ b/Sources/ZincFramework/Helpers/Lumberjack.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero. All rights reserved.
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 import Foundation
 // import os.log

--- a/Sources/ZincFramework/Helpers/ZincfileParser.swift
+++ b/Sources/ZincFramework/Helpers/ZincfileParser.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero. All rights reserved.
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 import Foundation
 

--- a/Sources/ZincFramework/Models/File.swift
+++ b/Sources/ZincFramework/Models/File.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero. All rights reserved.
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 import Foundation
 

--- a/Sources/ZincFramework/Models/Zincfile.swift
+++ b/Sources/ZincFramework/Models/Zincfile.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero. All rights reserved.
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 import Foundation
 

--- a/Sources/ZincFramework/Protocols/Command.swift
+++ b/Sources/ZincFramework/Protocols/Command.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero. All rights reserved.
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 protocol Command {
 //    var description: String

--- a/Sources/ZincFramework/Zinc.swift
+++ b/Sources/ZincFramework/Zinc.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero. All rights reserved.
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 import Foundation
 import Yams

--- a/Sources/zinc/main.swift
+++ b/Sources/zinc/main.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero. All rights reserved.
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 import Foundation
 import ZincFramework

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero. All rights reserved.
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 import XCTest
 

--- a/Tests/ZincTests/XCTestManifests.swift
+++ b/Tests/ZincTests/XCTestManifests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero. All rights reserved.
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 import XCTest
 

--- a/Tests/ZincTests/ZincTests.swift
+++ b/Tests/ZincTests/ZincTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2019 SpotHero. All rights reserved.
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 import class Foundation.Bundle
 import XCTest

--- a/Zincfile
+++ b/Zincfile
@@ -16,4 +16,5 @@ files:
   # SwiftLint
   - source_path: SwiftLint/.swiftlint.yml
   # SwiftFormat
-  - source_path: SwiftFormat/.swiftformat
+  # Removed until we have clearer header rules that would work across all projects
+  # - source_path: SwiftFormat/.swiftformat


### PR DESCRIPTION
**Description**
- Updated `SpotHero` in copyright to `SpotHero, Inc.`, the proper entity name.
- Re-implemented the `--header` rule in `.swiftformat`, which was replaced when running `zinc` last.
- Updated the `Zincfile` to exclude `.swiftformat` for the time being.