### PR TITLE
Added xcodeproj to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ playground.xcworkspace
 # Packages/
 # Package.pins
 .build/
+*.xcodeproj
 
 # CocoaPods
 #


### PR DESCRIPTION
**Description**
Adding `*.xcodeproj` to the gitignore will ensure it is never accidentally checked in.