### PR TITLE
Removed CommandHero, Lumberjack, and ShellRunner targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,10 @@ let package = Package(
     name: "Zinc",
     products: [
         .executable(name: "zinc", targets: ["zinc"]),
-        .library(name: "CommandHero", targets: ["CommandHero"]),
+        // .library(name: "CommandHero", targets: ["CommandHero"]),
         .library(name: "FileHero", targets: ["FileHero"]),
-        .library(name: "Lumberjack", targets: ["Lumberjack"]),
-        .library(name: "ShellRunner", targets: ["ShellRunner"]),
+        // .library(name: "Lumberjack", targets: ["Lumberjack"]),
+        // .library(name: "ShellRunner", targets: ["ShellRunner"]),
         .library(name: "ZincFramework", targets: ["ZincFramework"]),
     ],
     dependencies: [


### PR DESCRIPTION
**Description**
Removed CommandHero, Lumberjack, and ShellRunner targets so that they could be produced by the new CommandHero repository.
