### PR TITLE
Added --verbose flag to command

### DIFF
--- a/Sources/Lumberjack/Lumberjack.swift
+++ b/Sources/Lumberjack/Lumberjack.swift
@@ -10,7 +10,7 @@ public class Lumberjack {
     
     private static let debugPrefix = "⚙"
     
-    public var isDebugEnabled = true
+    public var isDebugEnabled = false
     
 //    Black: \u001b[30m
 //    Red: \u001b[31m

--- a/Sources/ZincFramework/Subcommands/SyncSubcommand.swift
+++ b/Sources/ZincFramework/Subcommands/SyncSubcommand.swift
@@ -13,10 +13,15 @@ class SyncSubcommand: Subcommand {
     public static var name = "sync"
     public static var usageDescription = "(default) Syncs local files with remote files as defined by a Zincfile."
     public static var arguments: [ArgumentDescribing] = []
-    public static var options: [OptionDescribing] = []
+    public static var options: [OptionDescribing] = [Options.isVerbose]
     
     // MARK: Options
     
+    public struct Options {
+        static let isVerbose = Option<Bool>("verbose", defaultValue: false, description: "Logs additional debug messages if enabled.")
+    }
+    
+    private let isVerbose: Bool
     private let file: String?
     
     // MARK: - Methods
@@ -25,11 +30,15 @@ class SyncSubcommand: Subcommand {
     
     public required init(from parser: ArgumentParser) throws {
         self.file = try parser.valueIfPresent(forOption: "file", shortName: "f")
+        
+        self.isVerbose = try parser.value(for: Options.isVerbose)
     }
     
     // MARK: Subcommand
     
     public func run() throws {
+        Lumberjack.shared.isDebugEnabled = self.isVerbose
+        
         try self.sync(self.file)
     }
     

--- a/Zincfile
+++ b/Zincfile
@@ -17,6 +17,3 @@ files:
   - source_path: Tools/SwiftLint/.swiftlint.yml
   # SwiftFormat
   - source_path: Tools/SwiftFormat/.swiftformat
-    name: .swiftformat
-  - source_path: Tools/GitHub/pull_request_template.md
-    destination_path: .github


### PR DESCRIPTION
**Description**
This PR implements the `--verbose` flag for the `sync` subcommand, which enables logging of Debug messages when enabled.