### PR TITLE
Updated README with open-source information

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,0 @@
-**JIRA URL**
-<!-- ex: https://spothero.atlassian.net/browse/IOS-#### -->
-
-**Description**
-<!-- Describe what items this PR changes. -->

--- a/README.md
+++ b/README.md
@@ -2,5 +2,6 @@
 
 [![Build Status](https://app.bitrise.io/app/3718292f3294869a/status.svg?token=-xKtZTJJ0qWeOiqGav0cXA&branch=master)](https://app.bitrise.io/app/3718292f3294869a)
 
-Zinc is a command-line tool for keeping local files in sync with files hosted outside of your folder or repository. 
+Zinc is a command-line tool for keeping local files in sync with files hosted outside of your folder or repository.
 
+>:warning: The code in this library has been provided as-is. It may lack the documentation, stability, and functionality necessary to support external use. While we work on improving this codebase, **use this library at your own risk** and please [reach out](#communication) if you have any questions or feedback.

--- a/Zincfile
+++ b/Zincfile
@@ -7,8 +7,6 @@ files:
   # GitHub
   - source_path: Tools/GitHub/CODEOWNERS
     destination_path: .github
-  - source_path: Tools/GitHub/pull_request_template.md
-    destination_path: .github
   - source_path: Tools/GitHub/.gitignore
   # Rubocop
   - source_path: Tools/Rubocop/rubocop.yml


### PR DESCRIPTION
**Description**
- Deleted the `pull_request_template.md` from this library and removed it from Zincfile. We'll rely on the Organization's [default community health file repository](http://github.com/spothero/.github) while it aligns.
- Updated README to include a notice of the state of the repository.