### PR TITLE
Updated bundler, fixed access levels

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,4 +65,4 @@ DEPENDENCIES
   danger-swiftlint (~> 0.24.1)
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/Sources/ZincFramework/Constants.swift
+++ b/Sources/ZincFramework/Constants.swift
@@ -1,6 +1,6 @@
 // Copyright © 2020 SpotHero, Inc. All rights reserved.
 
-class Constants {
+struct Constants {
     /// Denotes the default filenames to check if none are provided, in prioritized order.
     public static let defaultFilenames = [
         "Zincfile",

--- a/Sources/ZincFramework/Helpers/ZincfileParser.swift
+++ b/Sources/ZincFramework/Helpers/ZincfileParser.swift
@@ -6,7 +6,7 @@ import Foundation
 class ZincfileParser {
     static let shared = ZincfileParser()
     
-    /// Attempts to fetch a Zincfile with the given filename/
+    /// Attempts to fetch a Zincfile with the given filename.
     ///
     /// - Parameter filename: The filename of the Zincfile to fetch.
     /// - Returns: The fetched Zincfile if successful or nil if not.

--- a/Sources/ZincFramework/Models/File.swift
+++ b/Sources/ZincFramework/Models/File.swift
@@ -2,8 +2,8 @@
 
 import Foundation
 
-public class File: Codable {
-    static let defaultSource = "default"
+public struct File: Codable {
+    private static let defaultSource = "default"
     
     enum CodingKeys: String, CodingKey {
         case destinationPath = "destination_path"
@@ -41,7 +41,7 @@ public class File: Codable {
         return destinationPath
     }
     
-    public required init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
         self.destinationPath = try container.decodeIfPresent(String.self, forKey: .destinationPath) ?? ""

--- a/Sources/ZincFramework/Models/Zincfile.swift
+++ b/Sources/ZincFramework/Models/Zincfile.swift
@@ -4,7 +4,7 @@ import Foundation
 
 public typealias YamlDictionary = [String: String]
 
-public class Zincfile: Codable {
+public struct Zincfile: Codable {
     public enum Error: Swift.Error {
         case sourceConflict
     }
@@ -29,25 +29,9 @@ public class Zincfile: Codable {
     
     public var filename: String?
     
-    // public var allSources: YamlDictionary {
-    //     guard !self.source.isEmpty else {
-    //         return self.sources
-    //     }
-    
-    //     return ["default" : source].merging(self.sources, uniquingKeysWith: { (first, _) in first })
-    // }
-    
-//    public var description: String {
-//        do {
-//            return try YAMLEncoder().encode(self)
-//        } catch {
-//            return String(describing: self)
-//        }
-//    }
-    
     // MARK: Methods
     
-    public required init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
         self.files = try container.decodeIfPresent([File].self, forKey: .files) ?? []

--- a/Sources/ZincFramework/Subcommands/LintSubcommand.swift
+++ b/Sources/ZincFramework/Subcommands/LintSubcommand.swift
@@ -5,15 +5,15 @@ import FileHero
 import Lumberjack
 import ShellRunner
 
-class LintSubcommand: Subcommand {
+final class LintSubcommand: Subcommand {
     // MARK: - Properties
     
     // MARK: Command Metadata
     
-    public static var name = "lint"
-    public static var usageDescription = "Performs basic linting against a Zincfile to identify issues and errors."
-    public static var arguments: [ArgumentDescribing] = []
-    public static var options: [OptionDescribing] = []
+    static var name = "lint"
+    static var usageDescription = "Performs basic linting against a Zincfile to identify issues and errors."
+    static var arguments: [ArgumentDescribing] = []
+    static var options: [OptionDescribing] = []
     
     // MARK: Options
     
@@ -23,19 +23,19 @@ class LintSubcommand: Subcommand {
     
     // MARK: Initializers
     
-    public required init(from parser: ArgumentParser) throws {
+    required init(from parser: ArgumentParser) throws {
         self.file = try parser.valueIfPresent(forOption: "file", shortName: "f")
     }
     
     // MARK: Subcommand
     
-    public func run() throws {
+    func run() throws {
         try self.lint(self.file)
     }
     
     // MARK: Utilities
     
-    public func lint(_ filename: String? = nil) throws {
+    func lint(_ filename: String? = nil) throws {
         guard let zincfile = try ZincfileParser.shared.fetch(filename) else {
             return
         }

--- a/Sources/ZincFramework/Subcommands/SyncSubcommand.swift
+++ b/Sources/ZincFramework/Subcommands/SyncSubcommand.swift
@@ -5,19 +5,19 @@ import FileHero
 import Lumberjack
 import ShellRunner
 
-class SyncSubcommand: Subcommand {
+final class SyncSubcommand: Subcommand {
     // MARK: - Properties
     
     // MARK: Command Metadata
     
-    public static var name = "sync"
-    public static var usageDescription = "(default) Syncs local files with remote files as defined by a Zincfile."
-    public static var arguments: [ArgumentDescribing] = []
-    public static var options: [OptionDescribing] = [Options.isVerbose]
+    static var name = "sync"
+    static var usageDescription = "(default) Syncs local files with remote files as defined by a Zincfile."
+    static var arguments: [ArgumentDescribing] = []
+    static var options: [OptionDescribing] = [Options.isVerbose]
     
     // MARK: Options
     
-    public struct Options {
+    struct Options {
         static let isVerbose = Option<Bool>("verbose", defaultValue: false, description: "Logs additional debug messages if enabled.")
     }
     
@@ -28,7 +28,7 @@ class SyncSubcommand: Subcommand {
     
     // MARK: Initializers
     
-    public required init(from parser: ArgumentParser) throws {
+    required init(from parser: ArgumentParser) throws {
         self.file = try parser.valueIfPresent(forOption: "file", shortName: "f")
         
         self.isVerbose = try parser.value(for: Options.isVerbose)
@@ -36,7 +36,7 @@ class SyncSubcommand: Subcommand {
     
     // MARK: Subcommand
     
-    public func run() throws {
+    func run() throws {
         Lumberjack.shared.isDebugEnabled = self.isVerbose
         
         try self.sync(self.file)
@@ -44,7 +44,7 @@ class SyncSubcommand: Subcommand {
     
     // MARK: Utilities
     
-    private func sync(_ filename: String? = nil) throws {
+    func sync(_ filename: String? = nil) throws {
         guard let zincfile = try ZincfileParser.shared.fetch(filename) else {
             return
         }
@@ -72,8 +72,6 @@ class SyncSubcommand: Subcommand {
         // delete the temporary directory
         FileClerk.shared.removeTempDirectory()
     }
-    
-    // MARK: Utilities
     
     private func cloneDefaultRepository(_ zincfile: Zincfile) {
         guard !zincfile.source.isEmpty else {

--- a/Sources/ZincFramework/Subcommands/TestSubcommand.swift
+++ b/Sources/ZincFramework/Subcommands/TestSubcommand.swift
@@ -6,19 +6,19 @@
     import Foundation
     import Lumberjack
     
-    class TestSubcommand: Subcommand {
+    final class TestSubcommand: Subcommand {
         // MARK: - Properties
         
         // MARK: Command Metadata
         
-        public static var name = "test"
-        public static var usageDescription = "This command is used for testing Zinc in the debug build configuration."
-        public static var arguments: [ArgumentDescribing] = [Arguments.name]
-        public static var options: [OptionDescribing] = [Options.build, Options.dope, Options.file, Options.version]
+        static var name = "test"
+        static var usageDescription = "This command is used for testing Zinc in the debug build configuration."
+        static var arguments: [ArgumentDescribing] = [Arguments.name]
+        static var options: [OptionDescribing] = [Options.build, Options.dope, Options.file, Options.version]
         
         // MARK: Arguments
         
-        public struct Arguments {
+        struct Arguments {
             static let name = Argument<String>(index: 0, name: "name", description: "The name of the test.")
         }
         
@@ -26,7 +26,7 @@
         
         // MARK: Options
         
-        public struct Options {
+        struct Options {
             static let build = Option<Int>("build", shortName: "b", description: "The build number for the test.")
             static let dope = Option<Bool>("dope", shortName: "d", defaultValue: false, description: "Determines whether or not the test subcommand is dope.")
             static let file = Option<String>("file", shortName: "f", description: "Accepts a file to try to parse.")
@@ -42,7 +42,7 @@
         
         // MARK: Initializers
         
-        public required init(from parser: ArgumentParser) throws {
+        required init(from parser: ArgumentParser) throws {
             self.name = try parser.value(for: Arguments.name)
             
             self.file = try parser.valueIfPresent(for: Options.file)
@@ -53,7 +53,7 @@
         
         // MARK: Subcommand
         
-        public func run() throws {
+        func run() throws {
             Lumberjack.shared.log([
                 String(describing: self.name),
                 String(describing: self.file),

--- a/Sources/ZincFramework/Zinc.swift
+++ b/Sources/ZincFramework/Zinc.swift
@@ -5,7 +5,7 @@ import Foundation
 import Lumberjack
 import Yams
 
-public class Zinc: Command {
+public final class Zinc: Command {
     // MARK: Shared Instance
     
     public static let shared = Zinc()
@@ -17,14 +17,7 @@ public class Zinc: Command {
     
     public static var defaultSubcommand: String? = SyncSubcommand.name
     
-    #if DEBUG
-        public static var registeredSubcommands: [Subcommand.Type] = [
-            TestSubcommand.self,
-            SyncSubcommand.self,
-        ]
-    #else
-        public static var registeredSubcommands: [Subcommand.Type] = [
-            SyncSubcommand.self,
-        ]
-    #endif
+    public static var registeredSubcommands: [Subcommand.Type] = [
+        SyncSubcommand.self,
+    ]
 }


### PR DESCRIPTION
**Description**
- Bundler updated to `2.1.4`.
- Subcommand subclasses had their access level changed.
- Subcommand subclasses updated to `final class`.
- Changed `File` and `Zincfile` to `struct` from `class.
- Removed outdated comments.
